### PR TITLE
Set up GitHub Pages deployment and update site configuration

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,33 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Build with Astro
+        uses: withastro/action@v3
+        with:
+          package-manager: pnpm@latest
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,56 @@
+# CLAUDE.md
+
+## Project Overview
+
+Astro Nano — a minimal, lightweight static blog and portfolio site built with Astro. No frontend framework dependencies (no React/Vue/Svelte). MIT licensed.
+
+## Commands
+
+```bash
+npm run dev              # Start dev server (localhost:4321)
+npm run build            # Type-check (astro check) + build to ./dist/
+npm run preview          # Preview production build locally
+npm run lint             # Run ESLint
+npm run lint:fix         # Auto-fix ESLint issues
+```
+
+Package manager: **pnpm** (see `pnpm-lock.yaml`).
+
+## Tech Stack
+
+- **Astro 5** — static site generator with file-based routing
+- **TypeScript** (strict mode) — path alias `@*` → `./src/*`
+- **Tailwind CSS 3** — utility-first styling, class-based dark mode (`dark:` prefix)
+- **MDX** — markdown with component support for content
+- **Sharp** — image optimization
+
+## Project Structure
+
+- `src/pages/` — routes (index, blog, work, projects, rss.xml, robots.txt)
+- `src/components/` — Astro components (`.astro` files only)
+- `src/layouts/` — `PageLayout.astro` wraps all pages
+- `src/content/` — content collections (blog/, projects/, work/) with Zod schemas in `config.ts`
+- `src/consts.ts` — site configuration (name, email, social links, item counts)
+- `src/types.ts` — TypeScript types
+- `src/lib/utils.ts` — utilities (date formatting, reading time, classname merging)
+- `src/styles/global.css` — Tailwind directives and global styles
+- `public/` — static assets (favicons, images, fonts)
+
+## Code Conventions
+
+- **ESLint**: double quotes, semicolons required
+- All components are `.astro` files — no framework components
+- Tailwind utilities for all styling; prose styling via `@tailwindcss/typography`
+- Content posts use frontmatter with Zod-validated schemas (title, description, date, optional draft)
+- Dynamic routes use `[...slug].astro` pattern
+- Draft posts are filtered out in production builds
+
+## Content Schemas
+
+- **Blog**: title, description, date, draft?
+- **Projects**: title, description, date, draft?, demoURL?, repoURL?
+- **Work**: company, role, dateStart, dateEnd
+
+## No Test Suite
+
+There is no test runner configured. Code quality is enforced via ESLint and `astro check` (run as part of `npm run build`).

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -4,6 +4,6 @@ import sitemap from "@astrojs/sitemap";
 import tailwind from "@astrojs/tailwind";
 
 export default defineConfig({
-  site: "https://astro-nano-demo.vercel.app",
+  site: "https://stanete.com",
   integrations: [mdx(), sitemap(), tailwind()],
 });

--- a/public/CNAME
+++ b/public/CNAME
@@ -1,0 +1,1 @@
+stanete.com


### PR DESCRIPTION
## Summary
This PR configures automated deployment to GitHub Pages and updates the site configuration to point to the custom domain `stanete.com`.

## Changes
- **GitHub Actions Workflow**: Added `.github/workflows/deploy.yml` to automate building and deploying the Astro site to GitHub Pages on every push to `main` branch
  - Build step uses the official Astro GitHub Action with pnpm package manager
  - Deploy step uses GitHub's `actions/deploy-pages@v4` for reliable page deployment
  - Includes manual trigger support via `workflow_dispatch`

- **Site Configuration**: Updated `astro.config.mjs` to use custom domain `https://stanete.com` instead of the demo Vercel URL

- **Custom Domain Setup**: Added `public/CNAME` file to enable GitHub Pages custom domain routing

- **Documentation**: Added `CLAUDE.md` with comprehensive project overview including:
  - Tech stack details (Astro 5, TypeScript, Tailwind CSS, MDX)
  - Project structure and file organization
  - Available npm commands
  - Code conventions and content schemas
  - Development guidelines

## Implementation Details
The deployment workflow follows GitHub Pages best practices with proper permission scoping (`contents: read`, `pages: write`, `id-token: write`) and uses the latest stable versions of GitHub Actions. The CNAME file ensures the custom domain persists across deployments.

https://claude.ai/code/session_01RC13v9NVzgDqEXT3BycToo